### PR TITLE
Expand stringext dependency to support v0.15.x

### DIFF
--- a/src/Ar/WebSocket/ANSIC.lby
+++ b/src/Ar/WebSocket/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="0.02.0" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="0.02.1" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File>README.md</File>
     <File>LICENSE.txt</File>
@@ -22,7 +22,7 @@
   </Files>
   <Dependencies>
     <Dependency ObjectName="TCPComm" FromVersion="0.10.0" ToVersion="0.10.9" />
-    <Dependency ObjectName="StringExt" FromVersion="0.14.0" ToVersion="0.14.9" />
+    <Dependency ObjectName="StringExt" FromVersion="0.14.0" ToVersion="0.15.9" />
     <Dependency ObjectName="AsHttp" />
     <Dependency ObjectName="sys_lib" />
   </Dependencies>

--- a/src/Ar/WebSocket/CHANGELOG.md
+++ b/src/Ar/WebSocket/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 
+ - 0.02.1 - Expand StringExt dependency
  - 0.02.0 - Remove technology guarding license requirement
  - 0.01.0 - Update dependencies 
  - 0.00.2 - Add Client support


### PR DESCRIPTION
Expand StringExt dependency to support v0.15.x

StringExt v0.15.x is backwards-compatible with v0.14.x and should be allowed
