### PR TITLE
Fix missed Websocket disconnect messages

### DIFF
--- a/src/Ar/WebSocket/WSStream.c
+++ b/src/Ar/WebSocket/WSStream.c
@@ -44,28 +44,28 @@ void webSocketShiftReceivePointer(struct WSStream_typ* t, unsigned long bytes) {
 		t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength = 0;
 		
 		internalSetWSStreamError(t, WS_ERR_BUFFER_FULL, 0);
-		t->internal.debug.recieveBufferShiftFull++;
+		t->internal.debug.receiveBufferShiftFull++;
 	}
 	else {
 		t->internal.fub.tcpStream.IN.PAR.pReceiveData += bytes;
 		t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength -= bytes;
 	}
-	t->internal.debug.recieveBufferShift++;
-	t->internal.debug.recieveBufferIsShifted = 1;
+	t->internal.debug.receiveBufferShift++;
+	t->internal.debug.receiveBufferIsShifted = 1;
 }
 void webSocketResetReceivePointer(struct WSStream_typ* t) {
-	t->internal.fub.tcpStream.IN.PAR.pReceiveData = t->internal.recieveBuffer;
+	t->internal.fub.tcpStream.IN.PAR.pReceiveData = t->internal.receiveBuffer;
 	t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength = t->internal.bufferSize;
-	t->internal.debug.recieveBufferReset++;
-	t->internal.debug.recieveBufferIsShifted = 0;
+	t->internal.debug.receiveBufferReset++;
+	t->internal.debug.receiveBufferIsShifted = 0;
 }
 
 plcbit webSocketStreamInitialize(struct WSStream_typ* t) {
 	
 	t->internal.bufferSize = t->in.cfg.bufferSize + WS_HEADER_MAX_LEN;
 	
-	if(t->internal.recieveBuffer == 0)
-		if(TMP_alloc(t->internal.bufferSize, (void**)&t->internal.recieveBuffer) != 0) {
+	if(t->internal.receiveBuffer == 0)
+		if(TMP_alloc(t->internal.bufferSize, (void**)&t->internal.receiveBuffer) != 0) {
 			internalSetWSStreamError(t, WS_ERR_MEM_ALLOC, 0);
 		}
 	
@@ -75,12 +75,12 @@ plcbit webSocketStreamInitialize(struct WSStream_typ* t) {
 		}
 	
 	
-	t->internal.fub.tcpStream.IN.PAR.pReceiveData = t->internal.recieveBuffer;
+	t->internal.fub.tcpStream.IN.PAR.pReceiveData = t->internal.receiveBuffer;
 	t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength = t->internal.bufferSize-1;
 	t->internal.fub.tcpStream.IN.PAR.AllowContinuousSend = 1;
 	t->internal.fub.tcpStream.IN.PAR.pSendData = t->internal.sendBuffer;
 	
-	t->internal.initialized = (t->internal.recieveBuffer) && (t->internal.sendBuffer);
+	t->internal.initialized = (t->internal.receiveBuffer) && (t->internal.sendBuffer);
 	
 	return t->internal.initialized;
 }

--- a/src/Ar/WebSocket/WSStream.c
+++ b/src/Ar/WebSocket/WSStream.c
@@ -362,7 +362,6 @@ plcbit wsReceive(struct WSStream_typ* t)
 		else if(t->internal.fub.wsDecode.opCode == WS_OPCODE_CONNECTION_CLOSE) {
 			// Lets close gracefully
 			webSocketOnDisconnect(t);
-			webSocketResetReceivePointer(t);
 		}
 		else {
 			
@@ -389,7 +388,6 @@ plcbit wsReceive(struct WSStream_typ* t)
 					if(opCode == WS_OPCODE_CONNECTION_CLOSE) {
 						// Lets close gracefully
 						webSocketOnDisconnect(t);
-						webSocketResetReceivePointer(t);
 					}
 				}
 				

--- a/src/Ar/WebSocket/WSStream.c
+++ b/src/Ar/WebSocket/WSStream.c
@@ -371,6 +371,18 @@ plcbit wsReceive(struct WSStream_typ* t)
 			
 			if(!t->internal.fub.wsDecode.partialFrame) {
 			
+				if(t->internal.fub.wsDecode.decodeLength < t->internal.fub.tcpStream.OUT.ReceivedDataLength) {
+					// TODO: We should handle multiple packets better
+					// If we got another packet. Lets see if its a close message
+					USINT *pFrame = (USINT*)t->internal.fub.tcpStream.IN.PAR.pReceiveData + t->internal.fub.wsDecode.decodeLength;
+					USINT opCode = (*pFrame & 0x0f);
+					if(opCode == WS_OPCODE_CONNECTION_CLOSE) {
+						// Lets close gracefully
+						webSocketOnDisconnect(t);
+						webSocketResetReceivePointer(t);
+					}
+				}
+				
 				// We recieved a whole frame
 				webSocketResetReceivePointer(t); 
 			

--- a/src/Ar/WebSocket/WSStream.c
+++ b/src/Ar/WebSocket/WSStream.c
@@ -44,15 +44,20 @@ void webSocketShiftReceivePointer(struct WSStream_typ* t, unsigned long bytes) {
 		t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength = 0;
 		
 		internalSetWSStreamError(t, WS_ERR_BUFFER_FULL, 0);
+		t->internal.debug.recieveBufferShiftFull++;
 	}
 	else {
 		t->internal.fub.tcpStream.IN.PAR.pReceiveData += bytes;
 		t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength -= bytes;
 	}
+	t->internal.debug.recieveBufferShift++;
+	t->internal.debug.recieveBufferIsShifted = 1;
 }
 void webSocketResetReceivePointer(struct WSStream_typ* t) {
 	t->internal.fub.tcpStream.IN.PAR.pReceiveData = t->internal.recieveBuffer;
 	t->internal.fub.tcpStream.IN.PAR.MaxReceiveLength = t->internal.bufferSize;
+	t->internal.debug.recieveBufferReset++;
+	t->internal.debug.recieveBufferIsShifted = 0;
 }
 
 plcbit webSocketStreamInitialize(struct WSStream_typ* t) {
@@ -321,14 +326,15 @@ plcbit wsReceive(struct WSStream_typ* t)
 			}
 			else if(t->internal.fub.wsConnect.status != 0) {
 				// TODO: Handle errors
-				// TODO: Handle partial packets
 				internalSetWSStreamError(t, t->internal.fub.wsConnect.status, 0);
+				webSocketResetReceivePointer(t);
 			}
 			else {
 				webSocketResetReceivePointer(t);
 				t->internal.fub.tcpStream.IN.PAR.pSendData = t->internal.sendBuffer;
 				t->internal.fub.tcpStream.IN.PAR.SendLength = t->internal.fub.wsConnect.outputMessageLength;
 				t->internal.fub.tcpStream.IN.CMD.Send = 1;
+				//t->internal.connectionUpgraded = 1; // Lets try to set this here even though we have not sent the message yet
 			}
 		}
 		else if(t->internal.connection.mode == WS_MODE_CLIENT) {
@@ -359,6 +365,10 @@ plcbit wsReceive(struct WSStream_typ* t)
 			webSocketResetReceivePointer(t);
 		}
 		else {
+			
+			if(t->internal.fub.wsDecode.decodeLength < t->internal.fub.tcpStream.OUT.ReceivedDataLength) {
+				t->internal.debug.websocketPacketTooBig++;
+			}
 		
 			t->out.partialDataReceived = t->internal.fub.wsDecode.partialFrame || t->internal.fub.wsDecode.partialHeader;
 			t->out.header.fin = t->internal.fub.wsDecode.fin;
@@ -386,24 +396,24 @@ plcbit wsReceive(struct WSStream_typ* t)
 				// We recieved a whole frame
 				webSocketResetReceivePointer(t); 
 			
-//				if(t->internal.fub.wsDecode.mask && t->in.par.pReceiveData) {
-//					t->internal.fub.wsMask.pDest = t->in.par.pReceiveData;
-//					t->internal.fub.wsMask.destSize = t->in.par.maxReceiveLength;
-//					t->internal.fub.wsMask.pSrc = t->internal.fub.wsDecode.pPayloadData;
-//					t->internal.fub.wsMask.srcLength = t->internal.fub.wsDecode.payloadLength;
-//					
-//					memcpy(t->internal.fub.wsMask.maskingKey, t->internal.fub.wsDecode.maskingKey, sizeof(t->internal.fub.wsMask.maskingKey));
-//					
-//					WSMask(&t->internal.fub.wsMask);
-//					
-//					if(t->internal.fub.wsMask.status != 0) {
-//						internalSetWSStreamError(t, t->internal.fub.wsMask.status, 0);	
-//					}
-//				}
-//				else if(t->in.par.pReceiveData) {
-//					// TODO: Handle pRecieveData not being large enough
-//					memcpy((void*)t->in.par.pReceiveData, (void*)t->internal.fub.wsDecode.pPayloadData, t->internal.fub.wsDecode.payloadLength);
-//				}
+				//				if(t->internal.fub.wsDecode.mask && t->in.par.pReceiveData) {
+				//					t->internal.fub.wsMask.pDest = t->in.par.pReceiveData;
+				//					t->internal.fub.wsMask.destSize = t->in.par.maxReceiveLength;
+				//					t->internal.fub.wsMask.pSrc = t->internal.fub.wsDecode.pPayloadData;
+				//					t->internal.fub.wsMask.srcLength = t->internal.fub.wsDecode.payloadLength;
+				//					
+				//					memcpy(t->internal.fub.wsMask.maskingKey, t->internal.fub.wsDecode.maskingKey, sizeof(t->internal.fub.wsMask.maskingKey));
+				//					
+				//					WSMask(&t->internal.fub.wsMask);
+				//					
+				//					if(t->internal.fub.wsMask.status != 0) {
+				//						internalSetWSStreamError(t, t->internal.fub.wsMask.status, 0);	
+				//					}
+				//				}
+				//				else if(t->in.par.pReceiveData) {
+				//					// TODO: Handle pRecieveData not being large enough
+				//					memcpy((void*)t->in.par.pReceiveData, (void*)t->internal.fub.wsDecode.pPayloadData, t->internal.fub.wsDecode.payloadLength);
+				//				}
 			
 				t->out.dataReceived = 1;
 				t->out.receivedDataLength = t->internal.fub.wsDecode.payloadLength;
@@ -415,8 +425,8 @@ plcbit wsReceive(struct WSStream_typ* t)
 				
 				webSocketShiftReceivePointer(t, t->internal.fub.tcpStream.OUT.ReceivedDataLength); // Shift recieve pointer so we can append new data
 				
-//				t->out.dataReceived = 0;
-//				t->out.receivedDataLength = 0;
+				//				t->out.dataReceived = 0;
+				//				t->out.receivedDataLength = 0;
 			}
 		}
 	}

--- a/src/Ar/WebSocket/WSStream.c
+++ b/src/Ar/WebSocket/WSStream.c
@@ -353,6 +353,11 @@ plcbit wsReceive(struct WSStream_typ* t)
 			webSocketResetReceivePointer(t);
 			
 		}
+		else if(t->internal.fub.wsDecode.opCode == WS_OPCODE_CONNECTION_CLOSE) {
+			// Lets close gracefully
+			webSocketOnDisconnect(t);
+			webSocketResetReceivePointer(t);
+		}
 		else {
 		
 			t->out.partialDataReceived = t->internal.fub.wsDecode.partialFrame || t->internal.fub.wsDecode.partialHeader;

--- a/src/Ar/WebSocket/WSStream.typ
+++ b/src/Ar/WebSocket/WSStream.typ
@@ -66,15 +66,15 @@ TYPE
 		connectionState : UINT;
 		bufferSize : UDINT;
 		sendBuffer : UDINT;
-		recieveBuffer : UDINT;
+		receiveBuffer : UDINT;
 		prevSend : BOOL;
 	END_STRUCT;
 	WSStream_Int_Debug_typ : 	STRUCT 
 		websocketPacketTooBig : UDINT;
-		recieveBufferShiftFull : UDINT;
-		recieveBufferReset : UDINT;
-		recieveBufferShift : UDINT;
-		recieveBufferIsShifted : BOOL;
+		receiveBufferShiftFull : UDINT;
+		receiveBufferReset : UDINT;
+		receiveBufferShift : UDINT;
+		receiveBufferIsShifted : BOOL;
 	END_STRUCT;
 	WSStream_Int_FUB_typ : 	STRUCT 
 		tcpStream : TCPStream_typ;

--- a/src/Ar/WebSocket/WSStream.typ
+++ b/src/Ar/WebSocket/WSStream.typ
@@ -5,8 +5,8 @@
  * 
  * This file is part of WebSocket, licensed under the MIT License.
  *)
-
 (*For each client lets instantiate an interface*)
+
 TYPE
 	WSStream_typ : 	STRUCT 
 		in : WSStream_IN_typ;
@@ -70,7 +70,11 @@ TYPE
 		prevSend : BOOL;
 	END_STRUCT;
 	WSStream_Int_Debug_typ : 	STRUCT 
-		New_Member : USINT;
+		websocketPacketTooBig : UDINT;
+		recieveBufferShiftFull : UDINT;
+		recieveBufferReset : UDINT;
+		recieveBufferShift : UDINT;
+		recieveBufferIsShifted : BOOL;
 	END_STRUCT;
 	WSStream_Int_FUB_typ : 	STRUCT 
 		tcpStream : TCPStream_typ;


### PR DESCRIPTION
## What:

This will disconnect when receiving a Websocket message with opcode of close. 

## Why:

This solve a problem on browser refresh not closing the connection. We do not fully support multiple messages in a single call but we do handle it a little bit. This is because with Firefox we received the last message and the close message at the same time. 